### PR TITLE
feat: Improve failer system

### DIFF
--- a/example/config/failer.php
+++ b/example/config/failer.php
@@ -1,13 +1,13 @@
 <?php
 
 use Bdf\Queue\Failer\FailedJob;
-use Bdf\Queue\Failer\MemoryFailedJobStorage;
+use Bdf\Queue\Failer\MemoryFailedJobRepository;
 use Bdf\Queue\Message\QueuedMessage;
 
 $message = QueuedMessage::create("Foo");
 $message->setDestination('foo');
 
-$failer = new MemoryFailedJobStorage();
+$failer = new MemoryFailedJobRepository();
 $failer->store(FailedJob::create($message));
 
 return $failer;

--- a/example/lib/services.php
+++ b/example/lib/services.php
@@ -20,7 +20,7 @@ use Bdf\Queue\Destination\DestinationInterface;
 use Bdf\Queue\Destination\DestinationManager;
 use Bdf\Queue\Destination\DsnDestinationFactory;
 use Bdf\Queue\Failer\FailedJobStorageInterface;
-use Bdf\Queue\Failer\MemoryFailedJobStorage;
+use Bdf\Queue\Failer\MemoryFailedJobRepository;
 use Bdf\Queue\Serializer\BdfSerializer;
 use Bdf\Queue\Serializer\SerializerInterface;
 use Bdf\Serializer\SerializerBuilder;

--- a/src/Console/Command/Failer/AbstractFailerCommand.php
+++ b/src/Console/Command/Failer/AbstractFailerCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Bdf\Queue\Console\Command\Failer;
+
+use Bdf\Queue\Failer\FailedJob;
+use Bdf\Queue\Failer\FailedJobCriteria;
+use Bdf\Queue\Failer\FailedJobRepositoryAdapter;
+use Bdf\Queue\Failer\FailedJobRepositoryInterface;
+use Bdf\Queue\Failer\FailedJobStorageInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Base command class for perform operation on failed jobs
+ */
+abstract class AbstractFailerCommand extends Command
+{
+    /**
+     * @var FailedJobRepositoryInterface
+     * @read-only
+     */
+    protected $repository;
+
+    /**
+     * AbstractFailerCommand constructor.
+     *
+     * @param FailedJobStorageInterface $storage
+     */
+    public function __construct(FailedJobStorageInterface $storage)
+    {
+        parent::__construct(static::$defaultName);
+
+        $this->repository = FailedJobRepositoryAdapter::adapt($storage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('id', InputArgument::OPTIONAL, 'The ID of the failed job')
+            ->addOption('name', null, InputArgument::OPTIONAL, 'The message name. Wildcard can be used.')
+            ->addOption('connection', null, InputArgument::OPTIONAL, 'The queue connection name.')
+            ->addOption('queue', null, InputArgument::OPTIONAL, 'The queue name.')
+            ->addOption('error', null, InputArgument::OPTIONAL, 'Search for error message. Wildcard can be used.')
+            ->addOption('failedAt', null, InputArgument::OPTIONAL, 'Search for failing date. You can prefix the date with an operator like > or <.')
+            ->addOption('firstFailedAt', null, InputArgument::OPTIONAL, 'Search for original failing date. You can prefix the date with an operator like > or <.')
+            ->addOption('attempts', null, InputArgument::OPTIONAL, 'Filter by number of retry attempts. You can prefix the number with an operator like > or <.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($id = $input->getArgument('id')) {
+            return $this->handleOne($input, $output, $this->repository->findById($id));
+        } else {
+            return $this->handleCriteria($input, $output, $this->buildCriteria($input));
+        }
+    }
+
+    /**
+     * Handle job, when "id" argument is used
+     *
+     * @param InputInterface $input The CLI input
+     * @param OutputInterface $output The CLI output
+     * @param FailedJob|null $job The found job. Null is not found
+     *
+     * @return int The command result. 0 for success.
+     */
+    protected abstract function handleOne(InputInterface $input, OutputInterface $output, ?FailedJob $job): int;
+
+    /**
+     * Handle bulk operation, using a criteria
+     *
+     * @param InputInterface $input The CLI input
+     * @param OutputInterface $output The CLI output
+     * @param FailedJobCriteria $criteria The filter criteria
+     *
+     * @return int The command result. 0 for success.
+     */
+    protected abstract function handleCriteria(InputInterface $input, OutputInterface $output, FailedJobCriteria $criteria): int;
+
+    /**
+     * Build the criteria from CLI options
+     *
+     * @param InputInterface $input
+     *
+     * @return FailedJobCriteria
+     */
+    protected function buildCriteria(InputInterface $input): FailedJobCriteria
+    {
+        $criteria = new FailedJobCriteria();
+
+        if ($name = $input->getOption('name')) {
+            $criteria->name($name);
+        }
+
+        if ($connection = $input->getOption('connection')) {
+            $criteria->connection($connection);
+        }
+
+        if ($queue = $input->getOption('queue')) {
+            $criteria->queue($queue);
+        }
+
+        if ($error = $input->getOption('error')) {
+            $criteria->error($error);
+        }
+
+        if ($failedAt = $input->getOption('failedAt')) {
+            $criteria->failedAt($failedAt);
+        }
+
+        if ($firstFailedAt = $input->getOption('firstFailedAt')) {
+            $criteria->firstFailedAt($firstFailedAt);
+        }
+
+        if ($attempts = $input->getOption('attempts')) {
+            $criteria->attempts($attempts);
+        }
+
+        return $criteria;
+    }
+}

--- a/src/Console/Command/Failer/DeleteCommand.php
+++ b/src/Console/Command/Failer/DeleteCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Bdf\Queue\Console\Command\Failer;
+
+use Bdf\Queue\Failer\FailedJob;
+use Bdf\Queue\Failer\FailedJobCriteria;
+use Bdf\Queue\Failer\FailedJobStorageInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command for delete failed jobs
+ */
+class DeleteCommand extends AbstractFailerCommand
+{
+    protected static $defaultName = 'queue:failer:delete';
+
+    /**
+     * @param FailedJobStorageInterface $storage
+     */
+    public function __construct(FailedJobStorageInterface $storage)
+    {
+        parent::__construct($storage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setDescription('Delete failed queue jobs');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function handleOne(InputInterface $input, OutputInterface $output, ?FailedJob $job): int
+    {
+        if (!$job || !$this->repository->delete($job)) {
+            $output->writeln('<error>No failed job matches the given ID.</error>');
+
+            return 1;
+        }
+
+        $output->writeln('<info>Failed job deleted successfully</info>');
+
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function handleCriteria(InputInterface $input, OutputInterface $output, FailedJobCriteria $criteria): int
+    {
+        $count = $this->repository->purge($criteria);
+
+        $output->writeln(sprintf('<info>%d failed jobs deleted successfully</info>', $count));
+
+        return 0;
+    }
+}

--- a/src/Console/Command/Failer/FlushCommand.php
+++ b/src/Console/Command/Failer/FlushCommand.php
@@ -36,7 +36,7 @@ class FlushCommand extends Command
      */
     protected function configure(): void
     {
-        $this->setDescription('Flush all of the failed queue jobs');
+        $this->setDescription('Flush all of the failed queue jobs [deprecated]');
     }
     
     /**

--- a/src/Console/Command/Failer/ForgetCommand.php
+++ b/src/Console/Command/Failer/ForgetCommand.php
@@ -38,7 +38,7 @@ class ForgetCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Delete a failed queue job')
+            ->setDescription('Delete a failed queue job [deprecated]')
             ->addArgument('id', InputArgument::REQUIRED, 'The ID of the failed job')
         ;
     }

--- a/src/Failer/FailedJobCriteria.php
+++ b/src/Failer/FailedJobCriteria.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Bdf\Queue\Failer;
+
+use DateTime;
+use DateTimeInterface;
+use InvalidArgumentException;
+
+/**
+ * Store FailedJob search filters
+ * The criteria supports only on filter per field
+ *
+ * @see FailedJobStorageInterface::search()
+ */
+final class FailedJobCriteria
+{
+    const OPERATORS = ['>=', '<=', '>', '=', '<'];
+    const WILDCARD = 'wildcard';
+
+    /**
+     * @var array<string, array{string, mixed}>
+     */
+    private $criteria = [];
+
+    /**
+     * Search for message name
+     * You can use a wildcard "*" for perform partial search
+     *
+     * @param string $name The requested name
+     * @param value-of<FailedJobCriteria::OPERATORS>|null $operator
+     *
+     * @return $this
+     */
+    public function name(string $name, ?string $operator = null): self
+    {
+        [$name, $operator] = self::parseOperatorAndValue($name, $operator);
+
+        return $this->add('name', $operator, $name);
+    }
+
+    /**
+     * Search for connection name
+     * This search is strict, operators nor wildcard are supported
+     *
+     * @param string $connection
+     *
+     * @return $this
+     */
+    public function connection(string $connection): self
+    {
+        return $this->add('connection', '=', $connection);
+    }
+
+    /**
+     * Search for queue name
+     * This search is strict, operators nor wildcard are supported
+     *
+     * @param string $queue
+     *
+     * @return $this
+     */
+    public function queue(string $queue): self
+    {
+        return $this->add('queue', '=', $queue);
+    }
+
+    /**
+     * Search for error message
+     * You can use a wildcard "*" for perform partial search
+     *
+     * @param DateTimeInterface|string $error
+     * @param value-of<FailedJobCriteria::OPERATORS>|null $operator
+     *
+     * @return $this
+     */
+    public function error(string $error, ?string $operator = null): self
+    {
+        [$error, $operator] = self::parseOperatorAndValue($error, $operator);
+
+        return $this->add('error', $operator, $error);
+    }
+
+    /**
+     * Search for failing date
+     * Wildcard search can be used, if supported by the implementation
+     *
+     * @param DateTimeInterface|string $failedAt The failed date. Can be a string in format supported by PHP
+     * @param value-of<FailedJobCriteria::OPERATORS>|null $operator
+     *
+     * @return $this
+     */
+    public function failedAt($failedAt, ?string $operator = null): self
+    {
+        return $this->addDateTime('failedAt', $operator, $failedAt);
+    }
+
+    /**
+     * Search for initial failing date
+     * Wildcard search can be used, if supported by the implementation
+     *
+     * @param DateTimeInterface|string $failedAt The failed date. Can be a string in format supported by PHP
+     * @param value-of<FailedJobCriteria::OPERATORS>|null $operator
+     *
+     * @return $this
+     */
+    public function firstFailedAt($failedAt, ?string $operator = null): self
+    {
+        return $this->addDateTime('firstFailedAt', $operator, $failedAt);
+    }
+
+    /**
+     * Search for message name
+     *
+     * @param string|int $attempts The number of retry attempts. Can be prefixed by the operator.
+     * @param value-of<FailedJobCriteria::OPERATORS>|null $operator
+     *
+     * @return $this
+     */
+    public function attempts($attempts, ?string $operator = null): self
+    {
+        [$attempts, $operator] = self::parseOperatorAndValue($attempts, $operator);
+
+        return $this->add('attempts', $operator, (int) $attempts);
+    }
+
+    /**
+     * Add a new filter
+     *
+     * @param string $field The search field name
+     * @param string $operator The comparison operator
+     * @param mixed $value The compared value
+     *
+     * @return $this
+     */
+    public function add(string $field, string $operator, $value): self
+    {
+        $this->criteria[$field] = [$operator, $value];
+
+        return $this;
+    }
+
+    /**
+     * Export criteria to array format
+     *
+     * - The key is the field name
+     * - The first value is the operator
+     * - The second value is the compared value
+     *
+     * Format:
+     * array [
+     *     'field' => ['operator', value],
+     * ];
+     *
+     * @return array<string, array{string, mixed}>
+     */
+    public function toArray(): array
+    {
+        return $this->criteria;
+    }
+
+    /**
+     * Apply criteria to the query configurator
+     *
+     * The first argument is the field name
+     * The second is the operator
+     * The third is the compared value
+     *
+     * @param callable(string, string, mixed):void $queryConfigurator
+     *
+     * @return void
+     */
+    public function apply(callable $queryConfigurator): void
+    {
+        foreach ($this->criteria as $field => [$operator, $value]) {
+            $queryConfigurator($field, $operator, $value);
+        }
+    }
+
+    /**
+     * Check if a FailedJob entity match with the given criteria
+     *
+     * @param FailedJob $job
+     *
+     * @return bool
+     */
+    public function match(FailedJob $job): bool
+    {
+        foreach ($this->criteria as $field => [$operator, $value]) {
+            if (!self::matchSingleProperty($job->$field, $operator, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Search on a date field
+     * Wildcard search can be used, if supported by the implementation
+     *
+     * @param string $field The field name
+     * @param value-of<FailedJobCriteria::OPERATORS>|null $operator
+     * @param DateTimeInterface|string $date The date filter. Can be a string in format supported by PHP
+     *
+     * @return $this
+     */
+    private function addDateTime(string $field, ?string $operator, $date): self
+    {
+        if (is_string($date)) {
+            [$date, $operator] = self::parseOperatorAndValue($date, $operator);
+
+            // Allow search for date string using wildcard, like "2022-01-15*"
+            if ($operator !== self::WILDCARD) {
+                $date = new DateTime($date);
+            }
+        } elseif ($operator === null) {
+            $operator = '=';
+        }
+
+        return $this->add($field, $operator, $date);
+    }
+
+    /**
+     * Check for a single property value
+     *
+     * @param mixed $entityValue
+     * @param string $operator
+     * @param mixed $comparedValue
+     * @return bool
+     */
+    private static function matchSingleProperty($entityValue, string $operator, $comparedValue): bool
+    {
+        switch ($operator) {
+            case '=':
+                if (is_string($comparedValue)) {
+                    $entityValue = strtolower($entityValue);
+                    $comparedValue = strtolower($comparedValue);
+                }
+
+                return $entityValue == $comparedValue;
+
+            case '>':
+                return $entityValue > $comparedValue;
+
+            case '<':
+                return $entityValue < $comparedValue;
+
+            case '>=':
+                return $entityValue >= $comparedValue;
+
+            case '<=':
+                return $entityValue <= $comparedValue;
+
+            case FailedJobCriteria::WILDCARD:
+                if ($entityValue instanceof \DateTimeInterface) {
+                    $entityValue = $entityValue->format(DateTime::ATOM);
+                }
+
+                return preg_match('#^' . str_replace('\*', '.*', preg_quote($comparedValue)) . '$#i', $entityValue);
+
+            default:
+                throw new InvalidArgumentException('Unsupported operator ' . $operator);
+        }
+    }
+
+    /**
+     * Parse a filter value for extract the operator
+     *
+     * If the operator is not provided, it will be resolved from value :
+     * - If the value contains a wildcard "*", use WILDCARD operator
+     * - If the value starts with one of the known operator, it will be used, and the operator will be removed from value
+     * - Otherwise, "=" operator will be used
+     *
+     * @param mixed $value The compared value
+     * @param string|null $operator The requested operator
+     *
+     * @return array{mixed, string}
+     */
+    private static function parseOperatorAndValue(string $value, ?string $operator): array
+    {
+        if ($operator !== null) {
+            return [$value, $operator];
+        }
+
+        if (strpos($value, '*') !== false) {
+            return [$value, self::WILDCARD];
+        }
+
+        foreach (self::OPERATORS as $operator) {
+            if (strpos($value, $operator) === 0) {
+                return [ltrim(substr($value, strlen($operator))), $operator];
+            }
+        }
+
+        return [$value, '='];
+    }
+}

--- a/src/Failer/FailedJobRepositoryAdapter.php
+++ b/src/Failer/FailedJobRepositoryAdapter.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Bdf\Queue\Failer;
+
+/**
+ * Adapt legacy FailedJobStorageInterface to new FailedJobRepositoryInterface
+ * Filters will be applied "in memory", so it will be less effective than native handling
+ */
+final class FailedJobRepositoryAdapter implements FailedJobRepositoryInterface
+{
+    /**
+     * @var FailedJobStorageInterface
+     */
+    private $storage;
+
+    /**
+     * @param FailedJobStorageInterface $storage
+     */
+    private function __construct(FailedJobStorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store(FailedJob $job): void
+    {
+        $this->storage->store($job);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all(): iterable
+    {
+        return $this->storage->all();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findById($id): ?FailedJob
+    {
+        return $this->find($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function search(FailedJobCriteria $criteria): iterable
+    {
+        if ($criteria->toArray() === []) {
+            yield from $this->all();
+
+            return;
+        }
+
+        foreach ($this->all() as $job) {
+            if ($criteria->match($job)) {
+                yield $job;
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge(FailedJobCriteria $criteria): int
+    {
+        if ($criteria->toArray() === []) {
+            $this->flush();
+            return -1;
+        }
+
+        $count = 0;
+
+        foreach ($this->search($criteria) as $job) {
+            $this->delete($job);
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(FailedJob $job): bool
+    {
+        return $this->forget($job->id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($id)
+    {
+        return $this->storage->find($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function forget($id)
+    {
+        return $this->storage->forget($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $this->storage->flush();
+    }
+
+    /**
+     * Adapt a legacy storage to repository interface
+     *
+     * @param FailedJobStorageInterface $storage
+     *
+     * @return FailedJobRepositoryInterface
+     */
+    public static function adapt(FailedJobStorageInterface $storage): FailedJobRepositoryInterface
+    {
+        if ($storage instanceof FailedJobRepositoryInterface) {
+            return $storage;
+        }
+
+        return new self($storage);
+    }
+}

--- a/src/Failer/FailedJobRepositoryInterface.php
+++ b/src/Failer/FailedJobRepositoryInterface.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Bdf\Queue\Failer;
+
+/**
+ * Store and requests for FailedJob
+ */
+interface FailedJobRepositoryInterface extends FailedJobStorageInterface
+{
+    /**
+     * Store a failed job.
+     *
+     * @param FailedJob
+     *
+     * @return void
+     */
+    public function store(FailedJob $job): void;
+
+    /**
+     * List all failed jobs.
+     *
+     * @return iterable<FailedJob>
+     */
+    public function all(): iterable;
+
+    /**
+     * Get a single failed job by its id
+     *
+     * @param mixed $id The job id
+     *
+     * @return FailedJob|null The job instance, or null if not found
+     */
+    public function findById($id): ?FailedJob;
+
+    /**
+     * Search for failed jobs using a criteria
+     * For dump all jobs, use `all()` instead
+     *
+     * <code>
+     * $jobs = $storage->search((new FailedJobCriteria)
+     *     ->name('Foo*')
+     *     ->failedAt(new DateTime('2020-10-15'), '<=')
+     * );
+     *
+     * foreach ($jobs as $job) {
+     *     // ...
+     * }
+     * </code>
+     *
+     * @param FailedJobCriteria $criteria The search criteria
+     *
+     * @return iterable<FailedJob>
+     */
+    public function search(FailedJobCriteria $criteria): iterable;
+
+    /**
+     * Purge failed jobs using a criteria
+     *
+     * <code>
+     * $count = $storage->purge((new FailedJobCriteria)
+     *     ->name('Foo*')
+     *     ->failedAt(new DateTime('2020-10-15'), '<=')
+     * );
+     *
+     * if ($count > 0) {
+     *     echo $count, ' jobs removed';
+     * }
+     * </code>
+     *
+     * @param FailedJobCriteria $criteria
+     *
+     * @return positive-int
+     */
+    public function purge(FailedJobCriteria $criteria): int;
+
+    /**
+     * Delete one failed job
+     *
+     * @param FailedJob $job Job to delete
+     *
+     * @return bool true on success, or false if the job is not found
+     */
+    public function delete(FailedJob $job): bool;
+}

--- a/src/Failer/FailedJobStorageInterface.php
+++ b/src/Failer/FailedJobStorageInterface.php
@@ -4,6 +4,8 @@ namespace Bdf\Queue\Failer;
 
 /**
  * FailedJobStorageInterface
+ *
+ * @deprecated Use FailedJobRepositoryInterface instead
  */
 interface FailedJobStorageInterface
 {
@@ -11,13 +13,15 @@ interface FailedJobStorageInterface
      * Store a failed job.
      *
      * @param FailedJob
+     *
+     * @return void
      */
     public function store(FailedJob $job);
 
     /**
-     * Get a list of all of the failed jobs.
+     * List all failed jobs.
      *
-     * @return FailedJob[]|iterable
+     * @return iterable<FailedJob>
      */
     public function all();
 
@@ -27,6 +31,7 @@ interface FailedJobStorageInterface
      * @param mixed  $id
      * 
      * @return FailedJob
+     * @deprecated Use findById() instead
      */
     public function find($id);
 
@@ -36,11 +41,15 @@ interface FailedJobStorageInterface
      * @param mixed  $id
      * 
      * @return bool
+     * @deprecated Use delete() instead
      */
     public function forget($id);
 
     /**
-     * Flush all of the failed jobs from storage.
+     * Flush all failed jobs from storage.
+     *
+     * @return void
+     * @deprecated Use `purge()` instead
      */
     public function flush();
 }

--- a/src/Failer/MemoryFailedJobRepository.php
+++ b/src/Failer/MemoryFailedJobRepository.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Bdf\Queue\Failer;
+
+/**
+ * In-memory repository for failed jobs
+ */
+class MemoryFailedJobRepository implements FailedJobRepositoryInterface
+{
+    /**
+     * The prime connection
+     *
+     * @var FailedJob[]
+     */
+    private $storage = [];
+
+    /**
+     * The prime connection
+     *
+     * @var FailedJob[]
+     */
+    private $index = 1;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store(FailedJob $job): void
+    {
+        $toStore = clone $job;
+        $toStore->id = $this->index++;
+
+        $this->storage[$toStore->id] = $toStore;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all(): iterable
+    {
+        return array_values($this->storage);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($id)
+    {
+        return $this->findById($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function forget($id)
+    {
+        $exists = isset($this->storage[$id]);
+        unset($this->storage[$id]);
+
+        return $exists;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $this->storage = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findById($id): ?FailedJob
+    {
+        return $this->storage[$id] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function search(FailedJobCriteria $criteria): iterable
+    {
+        return array_filter($this->storage, [$criteria, 'match']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge(FailedJobCriteria $criteria): int
+    {
+        $removed = 0;
+
+        foreach ($this->storage as $key => $job) {
+            if ($criteria->match($job)) {
+                unset($this->storage[$key]);
+                ++$removed;
+            }
+        }
+
+        return $removed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(FailedJob $job): bool
+    {
+        return $this->forget($job->id);
+    }
+}

--- a/src/Failer/MemoryFailedJobStorage.php
+++ b/src/Failer/MemoryFailedJobStorage.php
@@ -3,67 +3,9 @@
 namespace Bdf\Queue\Failer;
 
 /**
- * MemoryFailedJobStorage
+ * @deprecated Use MemoryFailedJobRepository
  */
-class MemoryFailedJobStorage implements FailedJobStorageInterface
+class MemoryFailedJobStorage extends MemoryFailedJobRepository
 {
-    /**
-     * The prime connection
-     *
-     * @var FailedJob[]
-     */
-    private $storage = [];
 
-    /**
-     * The prime connection
-     *
-     * @var FailedJob[]
-     */
-    private $index = 1;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function store(FailedJob $job)
-    {
-        $toStore = clone $job;
-        $toStore->id = $this->index++;
-
-        $this->storage[$toStore->id] = $toStore;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function all()
-    {
-        return array_values($this->storage);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function find($id)
-    {
-        return $this->storage[$id] ?? null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function forget($id)
-    {
-        $exists = isset($this->storage[$id]);
-        unset($this->storage[$id]);
-
-        return $exists;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function flush()
-    {
-        $this->storage = [];
-    }
 }

--- a/tests/Failer/FailedJobCriteriaTest.php
+++ b/tests/Failer/FailedJobCriteriaTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Failer;
+
+use Bdf\Queue\Failer\FailedJob;
+use Bdf\Queue\Failer\FailedJobCriteria;
+use PHPUnit\Framework\TestCase;
+
+class FailedJobCriteriaTest extends TestCase
+{
+    public function test_empty()
+    {
+        $this->assertSame([], (new FailedJobCriteria())->toArray());
+    }
+
+    public function test_name()
+    {
+        $this->assertSame(['name' => ['=', 'foo']], (new FailedJobCriteria())->name('foo')->toArray());
+        $this->assertSame(['name' => ['>', 'foo']], (new FailedJobCriteria())->name('foo', '>')->toArray());
+        $this->assertSame(['name' => ['>', 'foo']], (new FailedJobCriteria())->name('> foo')->toArray());
+        $this->assertSame(['name' => ['wildcard', 'f*f*f']], (new FailedJobCriteria())->name('f*f*f')->toArray());
+    }
+
+    public function test_connection()
+    {
+        $this->assertSame(['connection' => ['=', 'foo']], (new FailedJobCriteria())->connection('foo')->toArray());
+        $this->assertSame(['connection' => ['=', 'f*f*f']], (new FailedJobCriteria())->connection('f*f*f')->toArray());
+    }
+
+    public function test_queue()
+    {
+        $this->assertSame(['queue' => ['=', 'foo']], (new FailedJobCriteria())->queue('foo')->toArray());
+        $this->assertSame(['queue' => ['=', 'f*f*f']], (new FailedJobCriteria())->queue('f*f*f')->toArray());
+    }
+
+    public function test_error()
+    {
+        $this->assertSame(['error' => ['=', 'foo']], (new FailedJobCriteria())->error('foo')->toArray());
+        $this->assertSame(['error' => ['>', 'foo']], (new FailedJobCriteria())->error('foo', '>')->toArray());
+        $this->assertSame(['error' => ['>', 'foo']], (new FailedJobCriteria())->error('> foo')->toArray());
+        $this->assertSame(['error' => ['wildcard', 'f*f*f']], (new FailedJobCriteria())->error('f*f*f')->toArray());
+    }
+
+    public function test_failedAt()
+    {
+        $this->assertEquals(['failedAt' => ['=', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->failedAt('2022-02-14')->toArray());
+        $this->assertEquals(['failedAt' => ['=', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->failedAt(new \DateTime('2022-02-14'))->toArray());
+        $this->assertEquals(['failedAt' => ['>', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->failedAt('2022-02-14', '>')->toArray());
+        $this->assertEquals(['failedAt' => ['>', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->failedAt(new \DateTime('2022-02-14'), '>')->toArray());
+        $this->assertEquals(['failedAt' => ['>', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->failedAt('> 2022-02-14')->toArray());
+        $this->assertSame(['failedAt' => ['wildcard', '2022-01-*']], (new FailedJobCriteria())->failedAt('2022-01-*')->toArray());
+    }
+
+    public function test_firstFailedAt()
+    {
+        $this->assertEquals(['firstFailedAt' => ['=', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->firstFailedAt('2022-02-14')->toArray());
+        $this->assertEquals(['firstFailedAt' => ['=', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->firstFailedAt(new \DateTime('2022-02-14'))->toArray());
+        $this->assertEquals(['firstFailedAt' => ['>', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->firstFailedAt('2022-02-14', '>')->toArray());
+        $this->assertEquals(['firstFailedAt' => ['>', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->firstFailedAt(new \DateTime('2022-02-14'), '>')->toArray());
+        $this->assertEquals(['firstFailedAt' => ['>', new \DateTime('2022-02-14')]], (new FailedJobCriteria())->firstFailedAt('> 2022-02-14')->toArray());
+        $this->assertSame(['firstFailedAt' => ['wildcard', '2022-01-*']], (new FailedJobCriteria())->firstFailedAt('2022-01-*')->toArray());
+    }
+
+    public function test_attempts()
+    {
+        $this->assertSame(['attempts' => ['=', 42]], (new FailedJobCriteria())->attempts(42)->toArray());
+        $this->assertSame(['attempts' => ['>', 42]], (new FailedJobCriteria())->attempts(42, '>')->toArray());
+        $this->assertSame(['attempts' => ['>', 42]], (new FailedJobCriteria())->attempts('> 42')->toArray());
+    }
+
+    public function test_match_empty()
+    {
+        $criteria = new FailedJobCriteria();
+
+        $this->assertTrue($criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+        ])));
+    }
+
+    /**
+     * @dataProvider provideSingleFilter
+     */
+    public function test_match_single_filter($filter, array $arguments, $match)
+    {
+        $criteria = new FailedJobCriteria();
+        $criteria->$filter(...$arguments);
+
+        $this->assertEquals($match, $criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+            'name' => 'Foo',
+            'error' => 'my error',
+            'failedAt' => new \DateTime('2022-01-10 12:45:00'),
+            'firstFailedAt' => new \DateTime('2022-01-08 08:30:00'),
+            'attempts' => 4,
+        ])));
+    }
+
+    public function test_match_multiple_filter()
+    {
+        $criteria = new FailedJobCriteria();
+        $criteria
+            ->name('f*')
+            ->attempts('> 3')
+        ;
+
+        $this->assertTrue($criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+            'name' => 'Foo',
+            'error' => 'my error',
+            'failedAt' => new \DateTime('2022-01-10 12:45:00'),
+            'firstFailedAt' => new \DateTime('2022-01-08 08:30:00'),
+            'attempts' => 4,
+        ])));
+
+        $this->assertFalse($criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+            'name' => 'Bar',
+            'error' => 'my error',
+            'failedAt' => new \DateTime('2022-01-10 12:45:00'),
+            'firstFailedAt' => new \DateTime('2022-01-08 08:30:00'),
+            'attempts' => 4,
+        ])));
+
+        $this->assertFalse($criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+            'name' => 'Foo',
+            'error' => 'my error',
+            'failedAt' => new \DateTime('2022-01-10 12:45:00'),
+            'firstFailedAt' => new \DateTime('2022-01-08 08:30:00'),
+            'attempts' => 2,
+        ])));
+    }
+
+    public function provideSingleFilter()
+    {
+        return [
+            ['name', ['foo'], true],
+            ['name', ['bar'], false],
+            ['name', ['F', '>'], true],
+            ['name', ['F', '<'], false],
+            ['name', ['> F'], true],
+            ['name', ['f*'], true],
+            ['name', ['b*'], false],
+            ['connection', ['test'], true],
+            ['connection', ['other'], false],
+            ['queue', ['queue'], true],
+            ['queue', ['other'], false],
+            ['error', ['my error'], true],
+            ['error', ['*error*'], true],
+            ['error', ['*other*'], false],
+            ['error', ['my', '>'], true],
+            ['failedAt', [new \DateTime('2022-01-10 12:45:00')], true],
+            ['failedAt', ['2022-01-10 12:45:00'], true],
+            ['failedAt', ['2022-01-10 12:45:30'], false],
+            ['failedAt', [new \DateTime('2022-01-10'), '>'], true],
+            ['failedAt', [new \DateTime('2022-01-10'), '<'], false],
+            ['failedAt', [new \DateTime('2022-02-01'), '<'], true],
+            ['failedAt', ['> 2022-01-10'], true],
+            ['failedAt', ['< 2022-01-10'], false],
+            ['failedAt', ['2022-01-*'], true],
+            ['failedAt', ['2021-01-*'], false],
+            ['firstFailedAt', [new \DateTime('2022-01-08 08:30:00')], true],
+            ['firstFailedAt', ['2022-01-08 08:30:00'], true],
+            ['firstFailedAt', ['2022-01-10 12:45:30'], false],
+            ['firstFailedAt', [new \DateTime('2022-01-08'), '>'], true],
+            ['firstFailedAt', [new \DateTime('2022-01-08'), '<'], false],
+            ['firstFailedAt', [new \DateTime('2022-02-01'), '<'], true],
+            ['firstFailedAt', ['> 2022-01-08'], true],
+            ['firstFailedAt', ['< 2022-01-08'], false],
+            ['firstFailedAt', ['2022-01-*'], true],
+            ['firstFailedAt', ['2021-01-*'], false],
+            ['attempts', [4], true],
+            ['attempts', [5], false],
+            ['attempts', [3, '>'], true],
+            ['attempts', [4, '>'], false],
+            ['attempts', [5, '<'], true],
+            ['attempts', ['< 5'], true],
+            ['attempts', ['> 5'], false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideOperators
+     */
+    public function test_match_operators(int $value, string $operator, bool $match)
+    {
+        $criteria = new FailedJobCriteria();
+        $criteria->attempts($value, $operator);
+
+        $this->assertEquals($match, $criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+            'name' => 'Foo',
+            'error' => 'my error',
+            'failedAt' => new \DateTime('2022-01-10 12:45:00'),
+            'firstFailedAt' => new \DateTime('2022-01-08 08:30:00'),
+            'attempts' => 4,
+        ])));
+    }
+
+    public function provideOperators()
+    {
+        return [
+            [4, '=', true],
+            [4, '>=', true],
+            [4, '<=', true],
+            [4, '>', false],
+            [4, '<', false],
+
+            [3, '=', false],
+            [3, '>=', true],
+            [3, '<=', false],
+            [3, '>', true],
+            [3, '<', false],
+
+            [5, '=', false],
+            [5, '>=', false],
+            [5, '<=', true],
+            [5, '>', false],
+            [5, '<', true],
+        ];
+    }
+
+    public function test_apply()
+    {
+        $criteria = new FailedJobCriteria();
+        $criteria
+            ->name('f*')
+            ->attempts('> 3')
+        ;
+
+        $calls = [];
+        $criteria->apply(function (...$args) use(&$calls) { $calls[] = $args; });
+
+        $this->assertSame([
+            ['name', 'wildcard', 'f*'],
+            ['attempts', '>', 3],
+        ], $calls);
+    }
+
+    public function test_match_invalid_operator()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported operator invalid');
+
+        $criteria = new FailedJobCriteria();
+        $criteria->attempts(4, 'invalid');
+
+        $criteria->match(new FailedJob([
+            'connection' => 'test',
+            'queue' => 'queue',
+            'messageContent' => ['job' => 'showCommand@test'],
+            'name' => 'Foo',
+            'error' => 'my error',
+            'failedAt' => new \DateTime('2022-01-10 12:45:00'),
+            'firstFailedAt' => new \DateTime('2022-01-08 08:30:00'),
+            'attempts' => 4,
+        ]));
+    }
+}

--- a/tests/Failer/FailedJobRepositoryAdapterTest.php
+++ b/tests/Failer/FailedJobRepositoryAdapterTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Failer;
+
+use Bdf\Queue\Failer\FailedJob;
+use Bdf\Queue\Failer\FailedJobCriteria;
+use Bdf\Queue\Failer\FailedJobRepositoryAdapter;
+use Bdf\Queue\Failer\FailedJobStorageInterface;
+use Bdf\Queue\Message\QueuedMessage;
+use PHPUnit\Framework\TestCase;
+
+class FailedJobRepositoryAdapterTest extends TestCase
+{
+    /**
+     * @var FailedJobRepositoryAdapter
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = FailedJobRepositoryAdapter::adapt(new class implements FailedJobStorageInterface {
+            public $storage = [];
+            public $lastId = 0;
+
+            public function store(FailedJob $job)
+            {
+                $job->id = ++$this->lastId;
+                $this->storage[$this->lastId] = $job;
+            }
+
+            public function all()
+            {
+                return $this->storage;
+            }
+
+            public function find($id)
+            {
+                return $this->storage[$id] ?? null;
+            }
+
+            public function forget($id)
+            {
+                if (isset($this->storage[$id])) {
+                    unset($this->storage[$id]);
+                    return true;
+                }
+
+                return false;
+            }
+
+            public function flush()
+            {
+                $this->storage = [];
+            }
+        });
+    }
+
+    /**
+     *
+     */
+    public function test_store_get()
+    {
+        $message = new QueuedMessage();
+        $message->setName('job');
+        $message->setConnection('queue-connection');
+        $message->setQueue('queue');
+
+        $created = FailedJob::create($message, new \Exception('foo'));
+
+        $this->repository->store($created);
+
+        $this->assertSame($this->repository->find(1), $this->repository->findById(1));
+    }
+
+    /**
+     *
+     */
+    public function test_delete()
+    {
+        $this->repository->store(new FailedJob([
+            'connection' => 'queue-connection',
+            'queue' => 'queue1',
+        ]));
+        $this->repository->store(new FailedJob([
+            'connection' => 'queue-connection',
+            'queue' => 'queue2',
+        ]));
+
+        $job = $this->repository->findById(1);
+
+        $result = $this->repository->delete($job);
+        $jobs = $this->repository->all();
+
+        $this->assertTrue($result);
+        $this->assertSame(1, count($jobs));
+
+        $this->assertFalse($this->repository->delete($job));
+    }
+
+    /**
+     * @dataProvider provideSearchCriteria
+     */
+    public function test_search(FailedJobCriteria $criteria, array $expectedIds)
+    {
+        $this->repository->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue1',
+            'name' => 'Foo',
+            'failedAt' => new \DateTime('2022-01-15 15:02:30'),
+            'error' => 'my error',
+        ]));
+        $this->repository->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue2',
+            'name' => 'Bar',
+            'failedAt' => new \DateTime('2022-01-15 22:14:15'),
+            'error' => 'my other error',
+        ]));
+        $this->repository->store(new FailedJob([
+            'connection' => 'conn2',
+            'queue' => 'queue2',
+            'name' => 'Baz',
+            'error' => 'hello world',
+            'failedAt' => new \DateTime('2021-12-21 08:00:35'),
+        ]));
+
+        $this->assertEqualsCanonicalizing($expectedIds, array_map(function (FailedJob $job) {
+            return $job->id;
+        }, iterator_to_array($this->repository->search($criteria))));
+    }
+
+    /**
+     * @dataProvider provideSearchCriteria
+     */
+    public function test_purge(FailedJobCriteria $criteria, array $expectedIds)
+    {
+        $this->repository->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue1',
+            'name' => 'Foo',
+            'failedAt' => new \DateTime('2022-01-15 15:02:30'),
+            'error' => 'my error',
+        ]));
+        $this->repository->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue2',
+            'name' => 'Bar',
+            'failedAt' => new \DateTime('2022-01-15 22:14:15'),
+            'error' => 'my other error',
+        ]));
+        $this->repository->store(new FailedJob([
+            'connection' => 'conn2',
+            'queue' => 'queue2',
+            'name' => 'Baz',
+            'error' => 'hello world',
+            'failedAt' => new \DateTime('2021-12-21 08:00:35'),
+        ]));
+
+        $ids = function () {
+            return array_map(
+                function (FailedJob $job) { return $job->id; },
+                $this->repository->all()
+            );
+        };
+
+        $remainingIds = array_diff($ids(), $expectedIds);
+
+        $this->assertEquals($criteria->toArray() ? count($expectedIds) : -1, $this->repository->purge($criteria));
+        $this->assertEqualsCanonicalizing($remainingIds, $ids());
+    }
+
+    public function provideSearchCriteria()
+    {
+        return [
+            'empty' => [new FailedJobCriteria(), [1, 2, 3]],
+            'connection' => [(new FailedJobCriteria())->connection('conn1'), [1, 2]],
+            'queue' => [(new FailedJobCriteria())->queue('queue2'), [2, 3]],
+            'name' => [(new FailedJobCriteria())->name('Foo'), [1]],
+            'name wildcard' => [(new FailedJobCriteria())->name('Ba*'), [2, 3]],
+            'name case insensitive' => [(new FailedJobCriteria())->name('foo'), [1]],
+            'error' => [(new FailedJobCriteria())->error('my error'), [1]],
+            'error wildcard' => [(new FailedJobCriteria())->error('my*error'), [1, 2]],
+            'error wildcard contains' => [(new FailedJobCriteria())->error('*or*'), [1, 2, 3]],
+            'failedAt with date' => [(new FailedJobCriteria())->failedAt(new \DateTime('2022-01-15 22:14:15')), [2]],
+            'failedAt with string' => [(new FailedJobCriteria())->failedAt('2022-01-15 22:14:15'), [2]],
+            'failedAt with wildcard' => [(new FailedJobCriteria())->failedAt('2022-01-15*'), [1, 2]],
+            'failedAt with operator' => [(new FailedJobCriteria())->failedAt('2022-01-01', '<'), [3]],
+            'failedAt with operator on value' => [(new FailedJobCriteria())->failedAt('> 2022-01-01'), [1, 2]],
+            'queue + connection' => [(new FailedJobCriteria())->connection('conn1')->queue('queue2'), [2]],
+            'none match' => [(new FailedJobCriteria())->name('Foo')->error('*world*'), []],
+        ];
+    }
+}

--- a/tests/Failer/MemoryFailedJobStorageTest.php
+++ b/tests/Failer/MemoryFailedJobStorageTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class MemoryFailedJobStorageTest extends TestCase
 {
     /**
-     * @var MemoryFailedJobStorage
+     * @var MemoryFailedJobRepository
      */
     private $provider;
 
@@ -21,7 +21,7 @@ class MemoryFailedJobStorageTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->provider = new MemoryFailedJobStorage();
+        $this->provider = new MemoryFailedJobRepository();
     }
 
     /**
@@ -102,6 +102,8 @@ class MemoryFailedJobStorageTest extends TestCase
         $this->provider->store($created);
         $job = $this->provider->find(1);
 
+        $this->assertSame($job, $this->provider->findById(1));
+
         $this->assertSame(1, $job->id);
         $this->assertSame($created->name, $job->name);
         $this->assertSame($created->connection, $job->connection);
@@ -157,6 +159,31 @@ class MemoryFailedJobStorageTest extends TestCase
     /**
      *
      */
+    public function test_delete()
+    {
+        $this->provider->store(new FailedJob([
+            'connection' => 'queue-connection',
+            'queue' => 'queue1',
+        ]));
+        $this->provider->store(new FailedJob([
+            'connection' => 'queue-connection',
+            'queue' => 'queue2',
+        ]));
+
+        $job = $this->provider->findById(1);
+
+        $result = $this->provider->delete($job);
+        $jobs = $this->provider->all();
+
+        $this->assertTrue($result);
+        $this->assertSame(1, count($jobs));
+
+        $this->assertFalse($this->provider->delete($job));
+    }
+
+    /**
+     *
+     */
     public function test_flush()
     {
         $this->provider->store(new FailedJob([
@@ -171,5 +198,99 @@ class MemoryFailedJobStorageTest extends TestCase
         $this->provider->flush();
 
         $this->assertSame(0, count($this->provider->all()));
+    }
+
+    /**
+     * @dataProvider provideSearchCriteria
+     */
+    public function test_search(FailedJobCriteria $criteria, array $expectedIds)
+    {
+        $this->provider->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue1',
+            'name' => 'Foo',
+            'failedAt' => new \DateTime('2022-01-15 15:02:30'),
+            'error' => 'my error',
+        ]));
+        $this->provider->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue2',
+            'name' => 'Bar',
+            'failedAt' => new \DateTime('2022-01-15 22:14:15'),
+            'error' => 'my other error',
+        ]));
+        $this->provider->store(new FailedJob([
+            'connection' => 'conn2',
+            'queue' => 'queue2',
+            'name' => 'Baz',
+            'error' => 'hello world',
+            'failedAt' => new \DateTime('2021-12-21 08:00:35'),
+        ]));
+
+        $this->assertEqualsCanonicalizing($expectedIds, array_map(function (FailedJob $job) {
+            return $job->id;
+        }, $this->provider->search($criteria)));
+    }
+
+    /**
+     * @dataProvider provideSearchCriteria
+     */
+    public function test_purge(FailedJobCriteria $criteria, array $expectedIds)
+    {
+        $this->provider->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue1',
+            'name' => 'Foo',
+            'failedAt' => new \DateTime('2022-01-15 15:02:30'),
+            'error' => 'my error',
+        ]));
+        $this->provider->store(new FailedJob([
+            'connection' => 'conn1',
+            'queue' => 'queue2',
+            'name' => 'Bar',
+            'failedAt' => new \DateTime('2022-01-15 22:14:15'),
+            'error' => 'my other error',
+        ]));
+        $this->provider->store(new FailedJob([
+            'connection' => 'conn2',
+            'queue' => 'queue2',
+            'name' => 'Baz',
+            'error' => 'hello world',
+            'failedAt' => new \DateTime('2021-12-21 08:00:35'),
+        ]));
+
+        $ids = function () {
+            return array_map(
+                function (FailedJob $job) { return $job->id; },
+                $this->provider->all()
+            );
+        };
+
+        $remainingIds = array_diff($ids(), $expectedIds);
+
+        $this->assertEquals(count($expectedIds), $this->provider->purge($criteria));
+        $this->assertEqualsCanonicalizing($remainingIds, $ids());
+    }
+
+    public function provideSearchCriteria()
+    {
+        return [
+            'empty' => [new FailedJobCriteria(), [1, 2, 3]],
+            'connection' => [(new FailedJobCriteria())->connection('conn1'), [1, 2]],
+            'queue' => [(new FailedJobCriteria())->queue('queue2'), [2, 3]],
+            'name' => [(new FailedJobCriteria())->name('Foo'), [1]],
+            'name wildcard' => [(new FailedJobCriteria())->name('Ba*'), [2, 3]],
+            'name case insensitive' => [(new FailedJobCriteria())->name('foo'), [1]],
+            'error' => [(new FailedJobCriteria())->error('my error'), [1]],
+            'error wildcard' => [(new FailedJobCriteria())->error('my*error'), [1, 2]],
+            'error wildcard contains' => [(new FailedJobCriteria())->error('*or*'), [1, 2, 3]],
+            'failedAt with date' => [(new FailedJobCriteria())->failedAt(new \DateTime('2022-01-15 22:14:15')), [2]],
+            'failedAt with string' => [(new FailedJobCriteria())->failedAt('2022-01-15 22:14:15'), [2]],
+            'failedAt with wildcard' => [(new FailedJobCriteria())->failedAt('2022-01-15*'), [1, 2]],
+            'failedAt with operator' => [(new FailedJobCriteria())->failedAt('2022-01-01', '<'), [3]],
+            'failedAt with operator on value' => [(new FailedJobCriteria())->failedAt('> 2022-01-01'), [1, 2]],
+            'queue + connection' => [(new FailedJobCriteria())->connection('conn1')->queue('queue2'), [2]],
+            'none match' => [(new FailedJobCriteria())->name('Foo')->error('*world*'), []],
+        ];
     }
 }

--- a/tests/FunctionnalTest.php
+++ b/tests/FunctionnalTest.php
@@ -20,7 +20,7 @@ use Bdf\Queue\Consumer\Receiver\StopWhenEmptyReceiver;
 use Bdf\Queue\Consumer\ReceiverInterface;
 use Bdf\Queue\Destination\DestinationManager;
 use Bdf\Queue\Exception\SerializationException;
-use Bdf\Queue\Failer\MemoryFailedJobStorage;
+use Bdf\Queue\Failer\MemoryFailedJobRepository;
 use Bdf\Queue\Message\EnvelopeInterface;
 use Bdf\Queue\Message\ErrorMessage;
 use Bdf\Queue\Message\Message;
@@ -536,7 +536,7 @@ class FunctionnalTest extends TestCase
      */
     public function test_failure()
     {
-        $failer = new MemoryFailedJobStorage();
+        $failer = new MemoryFailedJobRepository();
 
         $message = QueuedMessage::createFromJob(QueueHandler::class.'@error', 'test_queue_failed');
         $message->setAttempts(3);


### PR DESCRIPTION
- New interface `FailedJobRepositoryInterface` for storage
- Add filter system using `FailedJobCriteria`
- Adapter for compatibility between lagacy `FailedJobStorageInterface` and new `FailedJobRepositoryInterface`
- Modify show and retry commands to allows filtering by criteria
- Deprecates forget and flush commands
- Create delete command for deleting failed jobs filtered by criteria